### PR TITLE
remove clusterIP from spec (Service, Ingress)

### DIFF
--- a/eksporter.rb
+++ b/eksporter.rb
@@ -47,6 +47,9 @@ def clean_resource(resource)
   resource['metadata'].delete('selfLink')
   resource['metadata'].delete('uid')
   resource.delete('status')
+  if resource['spec'].has_key?('clusterIP')
+    resource['spec'].delete('clusterIP')
+  end
   resource
 end
 


### PR DESCRIPTION
Removing clusterIP allows for exporting/importing services between
clusters.

Implements https://github.com/Kyrremann/kubectl-eksporter/issues/3