### PR TITLE
Additional Key Check

### DIFF
--- a/eksporter.rb
+++ b/eksporter.rb
@@ -47,8 +47,10 @@ def clean_resource(resource)
   resource['metadata'].delete('selfLink')
   resource['metadata'].delete('uid')
   resource.delete('status')
-  if resource['spec'].has_key?('clusterIP')
-    resource['spec'].delete('clusterIP')
+  if resource.has_key?('spec')
+    if resource['spec'].has_key?('clusterIP')
+      resource['spec'].delete('clusterIP')
+    end
   end
   resource
 end


### PR DESCRIPTION
# What Does This PR Do?
This PR addresses a bug causing eksporter to crash when accessing `['spec']['clusterIP']`, in which a service without a clusterIP would cause a key error.